### PR TITLE
Use HPC job for cleanup stage and fix PNNL CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,6 @@
 .hykkt_script_template:
  script:
     - |
-      exit 1
       set -xv
       export WORKDIR="$HOME/gitlab/$CI_JOB_ID"
       if [[ ! -d "$WORKDIR" ]]; then

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 .hykkt_script_template:
  script:
     - |
+      exit 1
       set -xv
       export WORKDIR="$HOME/gitlab/$CI_JOB_ID"
       if [[ ! -d "$WORKDIR" ]]; then

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,7 +74,7 @@ hykkt-test-newell:
 SVC Account Cleanup:
   stage: .pre
   extends:
-   - .pnnl_nonhpc_tags
+   - .pnnl_tags_template
   script:
     - export WORKDIR="$HOME/gitlab/"
     # clears directory of files more than 1 day/1440 minutes old


### PR DESCRIPTION
Otherwise, job doesn't have access to the shared file system, and can't actually clean up jobs.

This PR will also be used for debugging pipeline status which was almost working in #1 