### PR TITLE
PNNL CI/CD Commit Status for Individual Pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,117 +1,12 @@
-.hykkt_script_template:
- script:
-    - |
-      set -xv
-      export WORKDIR="$HOME/gitlab/$CI_JOB_ID"
-      if [[ ! -d "$WORKDIR" ]]; then
-        mkdir -p "$WORKDIR"
-        cp -R ./* "$WORKDIR"
-      fi
-      cd $WORKDIR
-      [ -f output ] && rm output
-      touch output
-      tail -f output &
-      tailpid=$!
-      sinfo -l | grep $SLURM_Q
-      #test build script
-      jobid=$(sbatch --export=ALL -A EXASGD --gres=gpu:1 --ntasks=1 -p $SLURM_Q -o output -e output -t 60:00 $WORKDIR/buildsystem/build.sh $SCRIPT_ARGS)
-      
-      export jobid=$(echo $jobid | cut -f4 -d' ')
-      echo $jobid > "$WORKDIR/jobid"
-      res=1
-      while :;
-      do
-        if [[ "$(awk 'BEGIN{i=0}/BUILD_STATUS/{i++}END{print i}' output)" != "0" ]]; then
-          kill $tailpid
-          echo 'Last tail of build output:'
-          tail -n 200 output
-          res=$(grep BUILD_STATUS output | tail -n 1 | cut -f2 -d':')
-          break
-        fi
-        sleep 30
-      done
-      rm "$WORKDIR/jobid"
-      echo "Finished job with code $res"
-      exit $res
+trigger_deception:
+ trigger:
+   include:
+      - local: .gitlab/deception.gitlab-ci.yml
+      - local: .gitlab/basic.gitlab-ci.yml
+   
 
-
-.pnnl_tags_template:
-  tags:
-    - k8s
-    - ikp
-    - exasgd
-    - marianas
-    - deception
-
-.pnnl_nonhpc_tags:
-  tags:
-    - k8s
-    - ikp
-    - exasgd
-    - basic
-
-hykkt-test-deception:
-  stage: test
-  needs: []
-  variables:
-    SLURM_Q: "a100_shared"
-    MY_CLUSTER: "deception"
-  extends:
-    - .pnnl_tags_template
-    - .hykkt_script_template
-
-hykkt-test-newell:
-  stage: test
-  needs: []
-  variables:
-    SLURM_Q: "newell_shared"
-    MY_CLUSTER: "newell"
-  extends:
-  - .pnnl_tags_template
-  - .hykkt_script_template
-
-
-SVC Account Cleanup:
-  stage: .pre
-  extends:
-   - .pnnl_tags_template
-  script:
-    - export WORKDIR="$HOME/gitlab/"
-    # clears directory of files more than 1 day/1440 minutes old
-    - find $WORKDIR -D -type d -mindepth 1 -mmin +1440 -prune -print -exec rm -rf {} \; || true
-    - ls -hal $WORKDIR    
-
-.report-status:
-  image: mrnonz/alpine-git-curl:alpine3.16
-  variables:
-    GIT_STRATEGY: none
-    STATUS_PROJECT: ORNL/hykkt
-    STATUS_NAME: PNNL_CI
-  extends:
-  - .pnnl_nonhpc_tags
-  script:
-    - |
-      set -x
-      curl -L \
-      -X POST \
-      -H @${GITHUB_CURL_HEADER}\
-       https://api.github.com/repos/${STATUS_PROJECT}/statuses/${CI_COMMIT_SHA} \
-       -d "{\"state\":\"${CI_JOB_NAME}\",\"target_url\":\"${CI_PIPELINE_URL}\",\"context\":\"${STATUS_NAME}\"}"
-  environment:
-      name: reporting-gitlab
-pending:
-  extends:
-    - .report-status
-  stage: .pre
-
-success:
-  extends:
-    - .report-status
-  stage: .post
-
-failure:
-  stage: .post
-  extends:
-    - .report-status
-  rules:
-    - when: on_failure
+trigger_newell:
+  trigger:
+    include:
+      - local: .gitlab/newell.gitlab-ci.yml
+      - local: .gitlab/basic.gitlab-ci.yml

--- a/.gitlab/basic.gitlab-ci.yml
+++ b/.gitlab/basic.gitlab-ci.yml
@@ -1,0 +1,171 @@
+.hykkt_script_template:
+ script:
+    - |
+      set -xv
+      export WORKDIR="$HOME/gitlab/$CI_JOB_ID"
+      if [[ ! -d "$WORKDIR" ]]; then
+        mkdir -p "$WORKDIR"
+        cp -R ./* "$WORKDIR"
+      fi
+      pushd $WORKDIR
+      [ -f output ] && rm output
+      touch output
+      tail -f output &
+      tailpid=$!
+      #test build script
+      jobid=$(sbatch --export=ALL -A EXASGD --gres=gpu:1 --ntasks=1 -p $SLURM_Q -o output -e output -t 60:00 $WORKDIR/buildsystem/build.sh $SCRIPT_ARGS)
+      
+     
+      export jobid=$(echo $jobid | cut -f4 -d' ')
+      echo $jobid > "$WORKDIR/jobid_${jobid}"
+
+      partition=$(scontrol show jobid -dd $jobid | grep Partition)
+      export partition=$(echo $partition | cut -f2 -d'=' | cut -f1 -d' ')
+      
+      echo "Job $jobid submitted to partition $partition"
+      popd
+
+      echo "$partition" >> ./partition
+     
+      pushd $WORKDIR
+      res=1
+      while :;
+      do
+        if [[ "$(awk 'BEGIN{i=0}/BUILD_STATUS/{i++}END{print i}' output)" != "0" ]]; then
+          kill $tailpid
+          echo 'Last tail of build output:'
+          tail -n 200 output
+          res=$(grep BUILD_STATUS output | tail -n 1 | cut -f2 -d':')
+          break
+        fi
+        sleep 30
+      done
+      rm "$WORKDIR/jobid_${jobid}"
+      echo "Finished job with code $res"
+      exit $res
+
+.report-status:
+  image: mrnonz/alpine-git-curl:alpine3.16
+  variables:
+    GIT_STRATEGY: none
+    STATUS_PROJECT: ORNL/hykkt
+    STATUS_NAME: NotSet
+  extends:
+  - .pnnl_nonhpc_tags
+  script:
+    - |
+      set -x
+      if [[ ! -e partition ]]; then
+        echo "No partition file found"
+        export part="none"
+      else
+        export part=$(cat partition)
+      fi
+      
+      export newell_status="ppc64le/gcc@8.5.0/cuda@11.4/v100@70"
+      export deception_status="x86_64/gcc@9.1/cuda@11.4"
+     
+      if [[ "$part" == *"newell"*  ]]; then
+        export STATUS_NAME=$newell_status
+
+      elif [[ "$part" == *"a100"*  ]]; then
+        export gpu_arch=a100@80
+        export STATUS_NAME="$deception_status/$gpu_arch"
+
+      elif [[ "$part" == *"dl"*  ]]; then
+        gpu_arch=p100@60
+        export STATUS_NAME="$deception_status/$gpu_arch"
+
+      elif [[ "$part" == *"dlv"*  ]]; then
+        gpu_arch=v100@70
+        export STATUS_NAME="$deception_status/$gpu_arch"
+        
+      elif [[ "$part" == *"dlt"*  ]]; then
+        gpu_arch=RTX2080@75
+        export STATUS_NAME="$deception_status/$gpu_arch"
+        
+      else
+        echo "Unknown partition"
+        export STATUS_NAME="Unknown Partition"
+      fi
+      echo "GPU variable == $gpu_arch"
+      
+      curl -L \
+      -X POST \
+      -H @${GITHUB_CURL_HEADER}\
+       https://api.github.com/repos/${STATUS_PROJECT}/statuses/${CI_COMMIT_SHA} \
+       -d "{\"state\":\"${CI_JOB_NAME}\",\"target_url\":\"${CI_PIPELINE_URL}\",\"description\":\"${STATUS_NAME}\",\"context\":\"${MY_CLUSTER}\"}"
+  environment:
+    name: reporting-gitlab
+
+.report-pending:
+  image: mrnonz/alpine-git-curl:alpine3.16
+  variables:
+    GIT_STRATEGY: none
+    STATUS_PROJECT: ORNL/hykkt
+  extends: .pnnl_nonhpc_tags
+  script:
+   -  |
+      set -x
+      curl -L \
+      -X POST \
+      -H @${GITHUB_CURL_HEADER}\
+       https://api.github.com/repos/${STATUS_PROJECT}/statuses/${CI_COMMIT_SHA} \
+       -d "{\"state\":\"${CI_JOB_NAME}\",\"target_url\":\"${CI_PIPELINE_URL}\",\"context\":\"${MY_CLUSTER}\"}"
+  environment:
+    name: reporting-gitlab
+
+.pnnl_tags_template:
+  tags:
+    - k8s
+    - ikp
+    - exasgd
+    - marianas
+    - deception
+
+.pnnl_nonhpc_tags:
+  tags:
+    - k8s
+    - ikp
+    - exasgd
+    - basic
+
+.pnnl_after_script:
+  after_script:
+    - |
+      export WORKDIR="$HOME/gitlab/${CI_PIPELINE_ID}/"
+      # Iterate over possible jobid named files (jobid_%J)
+      job_ids="$WORKDIR/jobid_*"
+      for job in $job_ids
+      do
+        if [[ -f "$job" ]]; then
+          jobid=$(cat "$job")
+          scancel $jobid
+        fi
+      done
+      rm -rf $WORKDIR
+
+.cluster_test:
+  stage: test
+  needs: []
+  extends:
+    - .pnnl_tags_template
+    - .hykkt_script_template
+    - .pnnl_after_script
+  artifacts:
+    when: always
+    paths:
+      - partition
+
+.SVC-Account-Cleanup:
+  stage: .pre
+  extends:
+   - .pnnl_tags_template
+  script:
+    - export WORKDIR="$HOME/gitlab/"
+    # clears directory of files more than 1 hour/60 minutes old
+    - find $WORKDIR -D -type d -mindepth 1 -mmin +60 -prune -print -exec rm -rf {} \; || true
+    - ls -hal $WORKDIR    
+  allow_failure: true
+  resource_group: cleanup
+

--- a/.gitlab/deception.gitlab-ci.yml
+++ b/.gitlab/deception.gitlab-ci.yml
@@ -1,0 +1,38 @@
+
+cleanup:
+ stage: .pre
+ extends: .SVC-Account-Cleanup
+
+.deception:
+  variables:
+    MY_CLUSTER: "Deception"
+    SLURM_Q: "a100_shared,a100_80_shared,dl_shared,dlv,dlt_shared"
+    
+hykkt-test-deception:
+  extends:
+    - .deception
+    - .cluster_test 
+
+pending:
+  variables:
+    MY_CLUSTER: "Deception"
+  extends:
+    - .report-pending
+  stage: .pre
+
+success:
+  variables:
+    MY_CLUSTER: "Deception"
+  extends:
+    - .report-status
+  stage: .post
+       
+failure:
+  stage: .post
+  variables:
+    MY_CLUSTER: "Deception"
+  extends:
+    - .report-status
+  rules:
+    - when: on_failure
+  

--- a/.gitlab/newell.gitlab-ci.yml
+++ b/.gitlab/newell.gitlab-ci.yml
@@ -1,0 +1,39 @@
+
+cleanup:
+ stage: .pre
+ extends:
+  - .SVC-Account-Cleanup
+
+.newell:
+  variables:
+    MY_CLUSTER: "Newell"
+    SLURM_Q: "newell_shared"
+    
+hykkt-test-newell:
+  extends:
+    - .newell
+    - .cluster_test 
+
+
+pending:
+  variables:
+    MY_CLUSTER: "Newell"
+  extends:
+    - .report-pending
+  stage: .pre
+
+success:
+  variables:
+    MY_CLUSTER: "Newell"
+  extends:
+    - .report-status
+  stage: .post
+
+failure:
+  stage: .post
+  variables:
+    MY_CLUSTER: "Newell"
+  extends:
+    - .report-status
+  rules:
+    - when: on_failure

--- a/buildsystem/build.sh
+++ b/buildsystem/build.sh
@@ -69,8 +69,10 @@ then
   export MY_CLUSTER=`uname -n | sed -e 's/[0-9]//g' -e 's/\..*//'`
 fi
 
+export MY_CLUSTER_LOWER=$(echo ${MY_CLUSTER} | tr '[:upper:]' '[:lower:]')
+
 # Correctly identify clusters based on hostname
-case $MY_CLUSTER in
+case $MY_CLUSTER_LOWER in
   newell*)
     export MY_CLUSTER=newell
     ;;


### PR DESCRIPTION
Add separate pipeline updates for deception and newell based descriptions. The partition tested on is not included due to issues with CI/CD variables transferring from two different jobs that have two different runners. The fix would be using the shared filesystem. 