### PR TITLE
Quick patch for pipelines

### DIFF
--- a/.gitlab/basic.gitlab-ci.yml
+++ b/.gitlab/basic.gitlab-ci.yml
@@ -19,7 +19,7 @@
       export jobid=$(echo $jobid | cut -f4 -d' ')
       echo $jobid > "$WORKDIR/jobid_${jobid}"
 
-      partition=$(scontrol show jobid -dd $jobid | grep Partition)
+      partition=$(squeue -j $jobid -h --format="%P")
       export partition=$(echo $partition | cut -f2 -d'=' | cut -f1 -d' ')
       
       echo "Job $jobid submitted to partition $partition"


### PR DESCRIPTION
This patch is needed to get the individual pipelines status for deception and newell to show up. Not sure how this didn't get added through the merge request #9  but this one lines changes fixes it now. Should be an easy approve and merge. @pelesh 